### PR TITLE
Enable default set of nbextensions

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -8,6 +8,9 @@ set -eo pipefail
 
 /opt/app-root/builder/assemble
 
+# Install set of contrib nbextensions
+jupyter contrib nbextension install --sys-prefix
+
 # Activate ipywidgets extension.
 
 jupyter nbextension enable --py widgetsnbextension --sys-prefix


### PR DESCRIPTION
After this patch default set of nbextensions will be present in configurator manager (accessible via `edit` tab), by default none of them will be enabled (user call)

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   .s2i/bin/assemble