### PR TITLE
Update dependency versions and add plotnine package

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -16,6 +16,7 @@ networkx
 numpy
 pandas
 plotly
+plotnine
 requests
 scikit-learn
 scipy
@@ -27,24 +28,26 @@ jupyter_nbextensions_configurator
 
 # These are from actual s2i minimal notebook image
 #  https://github.com/jupyter-on-openshift/jupyter-notebooks/tree/master/scipy-notebook
-ipywidgets==7.0.*
-pandas==0.19.*
+ipywidgets==7.2.*
+pandas==0.23.*
 numexpr==2.6.*
-matplotlib==2.0.*
-scipy==0.19.*
-seaborn==0.7.*
-scikit-learn==0.18.*
-sympy==1.0.*
-cython==0.25.*
-patsy==0.4.*
-statsmodels==0.8.*
-cloudpickle==0.2.*
+matplotlib>=3.0.0  # from plotnine
+scipy==1.1.*
+seaborn==0.9.*
+scikit-learn==0.20.*
+scikit-image==0.14.*
+sympy==1.1.*
+cython==0.28.*
+patsy==0.5.*
+statsmodels==0.9.*
+cloudpickle==0.5.*
 dill==0.2.*
-numba==0.31.*
-bokeh==0.12.*
-sqlalchemy==1.1.*
-h5py==2.6.*
+numba==0.38.*
+bokeh==0.13.*
+sqlalchemy==1.2.*
+#hdf5==1.10.*
+h5py==2.7.*
 vincent==0.4.*
-beautifulsoup4==4.5.*
+beautifulsoup4==4.6.*
 protobuf==3.*
-xlrd==1.1.*
+xlrd==1.2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,25 +12,27 @@ async-timeout==3.0.1      # via aiohttp
 attrs==18.2.0             # via thoth-package-extract, thoth-python
 autopep8==1.4.3           # via thoth-solver
 backcall==0.1.0           # via ipython
-beautifulsoup4==4.5.3
+beautifulsoup4==4.6.3
 bleach==3.0.2             # via nbconvert
-bokeh==0.12.16
+bokeh==0.13.0
 boto3==1.9.59             # via thoth-storages
 botocore==1.12.59         # via boto3, s3transfer
 certifi==2018.11.29       # via amun, requests, sentry-sdk
 chardet==3.0.4            # via aiohttp, requests
 click==6.6                # via flask, pip-tools, thoth-adviser, thoth-analyzer, thoth-package-extract, thoth-python, thoth-solver
-cloudpickle==0.2.2
+cloudpickle==0.5.6
 colorama==0.4.1           # via rainbow-logging-handler
 contoml==0.32             # via thoth-python
 cycler==0.10.0            # via matplotlib
-cython==0.25.2
+cython==0.28.6
 daiquiri==1.5.0           # via thoth-common, thoth-package-extract
 dash-renderer==0.15.1     # via dash
 dash==0.31.1
+dask[array]==1.1.1        # via scikit-image
 decorator==4.3.0          # via ipython, networkx, plotly, traitlets
 defusedxml==0.5.0         # via nbconvert
 delegator.py==0.1.1       # via thoth-analyzer
+descartes==1.1.0          # via plotnine
 dill==0.2.8.2
 distro==1.3.0             # via thoth-analyzer
 docutils==0.14            # via botocore
@@ -39,14 +41,14 @@ flask-compress==1.4.0     # via dash
 flask==1.0.2              # via dash, flask-compress
 goblin==2.1.0             # via thoth-storages
 gremlinpython==3.2.6      # via thoth-storages
-h5py==2.6.0
+h5py==2.7.1
 holoviews==1.10.9
 idna==2.7                 # via requests, yarl
 inflection==0.3.1         # via goblin
 ipykernel==5.1.0          # via ipywidgets, notebook
 ipython-genutils==0.2.0   # via jupyter-contrib-nbextensions, nbformat, notebook, traitlets
 ipython==7.2.0            # via ipykernel, ipywidgets, jupyter-latex-envs
-ipywidgets==7.0.5
+ipywidgets==7.2.1
 iso8601==0.1.12           # via contoml
 itsdangerous==1.1.0       # via flask
 jedi==0.13.1              # via ipython
@@ -60,32 +62,37 @@ jupyter-core==4.4.0       # via jupyter-client, jupyter-contrib-core, jupyter-co
 jupyter-highlight-selected-word==0.2.0  # via jupyter-contrib-nbextensions
 jupyter-latex-envs==1.4.6  # via jupyter-contrib-nbextensions
 jupyter-nbextensions-configurator==0.4.0
+kiwisolver==1.0.1         # via matplotlib
 llvmlite==0.26.0          # via numba
 logutils==0.3.5           # via rainbow-logging-handler
 lxml==4.2.5               # via jupyter-contrib-nbextensions, thoth-python
 markupsafe==1.1.0         # via jinja2
-matplotlib==2.0.2
+matplotlib==3.0.2
 mistune==0.8.4            # via nbconvert
+mizani==0.5.3             # via plotnine
 mpmath==1.0.0             # via sympy
 multidict==4.5.2          # via aiohttp, yarl
 nbconvert==5.4.0          # via jupyter-contrib-nbextensions, jupyter-latex-envs, notebook
 nbformat==4.4.0           # via ipywidgets, nbconvert, notebook, plotly
 networkx==2.2
 notebook==5.7.2           # via jupyter-contrib-core, jupyter-contrib-nbextensions, jupyter-latex-envs, jupyter-nbextensions-configurator, widgetsnbextension
-numba==0.31.0
+numba==0.38.1
 numexpr==2.6.8
 numpy==1.15.4
 packaging==18.0           # via bokeh
-pandas==0.19.2
+palettable==3.1.1         # via mizani
+pandas==0.23.4
 pandocfilters==1.4.2      # via nbconvert
 param==1.8.1              # via holoviews, pyviz-comms
 parso==0.3.1              # via jedi
-patsy==0.4.1
+patsy==0.5.1
 pexpect==4.6.0            # via delegator.py, ipython
 pickleshare==0.7.5        # via ipython
+pillow==5.4.1             # via scikit-image
 pip-tools==3.1.0          # via thoth-solver
 pipdeptree==0.13.1        # via thoth-solver
 plotly==3.4.2
+plotnine==0.5.1
 prometheus-client==0.4.2  # via notebook
 prompt-toolkit==2.0.7     # via ipython
 protobuf==3.6.1
@@ -94,8 +101,9 @@ pycodestyle==2.4.0        # via autopep8
 pygments==2.3.0           # via ipython, nbconvert
 pyparsing==2.3.0          # via matplotlib, packaging
 python-dateutil==2.7.5    # via amun, bokeh, botocore, jupyter-client, matplotlib, pandas
-pytz==2018.7              # via contoml, matplotlib, pandas, plotly, rfc5424-logging-handler, tzlocal
+pytz==2018.7              # via contoml, pandas, plotly, rfc5424-logging-handler, tzlocal
 pyviz-comms==0.6.0        # via holoviews
+pywavelets==1.0.1         # via scikit-image
 pyyaml==3.12              # via aiogremlin, bokeh, jupyter-contrib-nbextensions, jupyter-nbextensions-configurator
 pyzmq==17.1.2             # via jupyter-client, notebook
 rainbow-logging-handler==2.2.2  # via thoth-solver
@@ -103,17 +111,18 @@ requests==2.20.1
 retrying==1.3.3           # via plotly
 rfc5424-logging-handler==1.3.0  # via thoth-common
 s3transfer==0.1.13        # via boto3
-scikit-learn==0.18.2
-scipy==0.19.1
-seaborn==0.7.1
+scikit-image==0.14.2
+scikit-learn==0.20.2
+scipy==1.1.0
+seaborn==0.9.0
 semantic-version==2.6.0   # via thoth-python
 send2trash==1.5.0         # via notebook
 sentry-sdk==0.6.1         # via thoth-common
-six==1.10.0               # via aiogremlin, amun, bleach, bokeh, contoml, cycler, gremlinpython, h5py, matplotlib, packaging, patsy, pip-tools, plotly, prompt-toolkit, protobuf, python-dateutil, retrying, traitlets
-sqlalchemy==1.1.18
-statsmodels==0.8.0
+six==1.10.0               # via aiogremlin, amun, bleach, bokeh, contoml, cycler, gremlinpython, h5py, packaging, patsy, pip-tools, plotly, prompt-toolkit, protobuf, python-dateutil, retrying, scikit-image, traitlets
+sqlalchemy==1.2.17
+statsmodels==0.9.0
 strict-rfc3339==0.7       # via contoml
-sympy==1.0
+sympy==1.1.1
 terminado==0.8.1          # via notebook
 testpath==0.4.2           # via nbconvert
 thoth-adviser==0.3.0
@@ -125,6 +134,7 @@ thoth-python==0.3.1
 thoth-solver==1.1.0
 thoth-storages==0.9.3
 timestamp==0.0.1          # via contoml
+toolz==0.9.0              # via dask
 tornado==4.4.1            # via bokeh, gremlinpython, ipykernel, jupyter-client, jupyter-contrib-core, jupyter-contrib-nbextensions, jupyter-nbextensions-configurator, notebook, terminado
 traitlets==4.3.2          # via ipykernel, ipython, ipywidgets, jupyter-client, jupyter-contrib-core, jupyter-contrib-nbextensions, jupyter-core, jupyter-latex-envs, jupyter-nbextensions-configurator, nbconvert, nbformat, notebook
 tzlocal==1.5.1            # via rfc5424-logging-handler
@@ -137,6 +147,6 @@ voluptuous==0.11.5        # via thoth-storages
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5.1       # via bleach
 werkzeug==0.14.1          # via flask
-widgetsnbextension==3.0.8  # via ipywidgets
-xlrd==1.1.0
+widgetsnbextension==3.2.1  # via ipywidgets
+xlrd==1.2.0
 yarl==1.1.1               # via aiohttp, thoth-storages


### PR DESCRIPTION
- from [plotnine github page]: [plotnine] is an implementation of a grammar of graphics
in Python, it is based on ggplot2. The grammar allows users to compose
plots by explicitly mapping data to the visual objects that make up the
plot.

- update dependency version (also considered [scipy-notebook] requirements

[plotnine github page]: https://github.com/has2k1/plotnine
[plotnine]: https://plotnine.readthedocs.io/en/stable/

[scipy-notebook]: https://github.com/jupyter-on-openshift/jupyter-notebooks/blob/master/scipy-notebook/requirements.txt

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   requirements.in
modified:   requirements.txt