### PR TITLE
Update plotly to 4.0* and remove cufflinks because not compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ click==6.6
 cloudpickle==0.5.6
 colorama==0.4.1
 contoml==0.32
-cufflinks==0.16
 cycler==0.10.0
 cython==0.28.6
 daiquiri==1.5.0
@@ -85,7 +84,7 @@ pickleshare==0.7.5
 pillow==6.0.0
 pip-tools==3.8.0
 pipdeptree==0.13.2
-plotly==3.6.1
+plotly==4.0.*
 plotnine==0.5.1
 prettyprinter==0.18.0
 prometheus-client==0.7.0


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>